### PR TITLE
chore: upgrade api-client to version 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.6.0",
-        "@neondatabase/api-client": "1.13.0",
+        "@neondatabase/api-client": "2.0.0",
         "@neondatabase/serverless": "0.10.4",
         "chalk": "5.3.0",
         "node-fetch": "2.7.0",
@@ -985,9 +985,9 @@
       }
     },
     "node_modules/@neondatabase/api-client": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-1.13.0.tgz",
-      "integrity": "sha512-grB9eW8YBS6oJe1Hun9mAzebpW2+ZoWb3BVKM1dhkYV/ZAtEOX2VOxwUcRKmi5PGA7xYItgszsKQuuQv068ULQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/api-client/-/api-client-2.0.0.tgz",
+      "integrity": "sha512-UwjRRy8gyShNDfbbP1N+rA235FzqVWP/WPi4cgLnkGgConqpiR+U9Dsegaxu+HxAgK678kQ/5wc4/EPexvE7tw==",
       "dependencies": {
         "axios": "^1.7.9"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.6.0",
-    "@neondatabase/api-client": "1.13.0",
+    "@neondatabase/api-client": "2.0.0",
     "@neondatabase/serverless": "0.10.4",
     "chalk": "5.3.0",
     "node-fetch": "2.7.0",

--- a/src/handlers/neon-auth.ts
+++ b/src/handlers/neon-auth.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { neonClient } from '../index.js';
-import { IdentitySupportedAuthProvider } from '@neondatabase/api-client';
+import { NeonAuthSupportedAuthProvider } from '@neondatabase/api-client';
 import { provisionNeonAuthInputSchema } from '../toolsSchema.js';
 import { z } from 'zod';
 
@@ -45,8 +45,8 @@ export async function handleProvisionNeonAuth({
     };
   }
 
-  const response = await neonClient.createProjectIdentityIntegration({
-    auth_provider: IdentitySupportedAuthProvider.Stack,
+  const response = await neonClient.createNeonAuthIntegration({
+    auth_provider: NeonAuthSupportedAuthProvider.Stack,
     project_id: projectId,
     branch_id: defaultBranch.id,
     database_name: defaultDatabase.name,


### PR DESCRIPTION
Upgrade the `api-client` to version 2.0 after the name change of API handler

cc: @davidgomes 