### PR TITLE
fix: do not assume 'neondb' and 'neondb_owner' exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## UNRELEASED
 
+- Extract utility function for getting the default database
+
 ## [0.3.4] - 2025-03-26
 
 - Add `neon-auth`, `neon-serverless`, and `neon-drizzle` resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Improve database selection by standardizing how default databases are identified and used
+- Fix database name assumption
 
 ## [0.3.4] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Extract utility function for getting the default database
+- Improve database selection by standardizing how default databases are identified and used
 
 ## [0.3.4] - 2025-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Fix database name assumption
+- Fix default database name or role name assumptions.
 
 ## [0.3.4] - 2025-03-26
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,1 @@
-export const NEON_DEFAULT_ROLE_NAME = 'neondb_owner';
 export const NEON_DEFAULT_DATABASE_NAME = 'neondb';

--- a/src/handlers/neon-auth.ts
+++ b/src/handlers/neon-auth.ts
@@ -28,19 +28,11 @@ export async function handleProvisionNeonAuth({
       ],
     };
   }
-  const databaseName = await getDefaultDatabase({
+  const defaultDatabase = await getDefaultDatabase({
     projectId,
     branchId: defaultBranch.id,
     databaseName: database,
   });
-
-  const { data } = await neonClient.getProjectBranchDatabase(
-    projectId,
-    defaultBranch.id,
-    databaseName,
-  );
-
-  const defaultDatabase = data.database;
 
   if (!defaultDatabase) {
     return {

--- a/src/handlers/neon-auth.ts
+++ b/src/handlers/neon-auth.ts
@@ -3,6 +3,7 @@ import { neonClient } from '../index.js';
 import { NeonAuthSupportedAuthProvider } from '@neondatabase/api-client';
 import { provisionNeonAuthInputSchema } from '../toolsSchema.js';
 import { z } from 'zod';
+import { getDefaultDatabase } from '../utils.js';
 
 type Props = z.infer<typeof provisionNeonAuthInputSchema>;
 export async function handleProvisionNeonAuth({
@@ -27,11 +28,19 @@ export async function handleProvisionNeonAuth({
       ],
     };
   }
-  const {
-    data: { databases },
-  } = await neonClient.listProjectBranchDatabases(projectId, defaultBranch.id);
-  const defaultDatabase =
-    databases.find((db) => db.name === database) ?? databases[0];
+  const databaseName = await getDefaultDatabase({
+    projectId,
+    branchId: defaultBranch.id,
+    databaseName: database,
+  });
+
+  const { data } = await neonClient.getProjectBranchDatabase(
+    projectId,
+    defaultBranch.id,
+    databaseName,
+  );
+
+  const defaultDatabase = data.database;
 
   if (!defaultDatabase) {
     return {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -625,12 +625,6 @@ async function handleGetConnectionString({
     roleName = data.database.owner_name;
   }
 
-  if (!roleName || !databaseName) {
-    throw new Error(
-      'Role name and database name are required for connection string',
-    );
-  }
-
   // Get connection URI with the provided parameters
   const connectionString = await neonClient.getConnectionUri({
     projectId,
@@ -678,10 +672,6 @@ async function handleSchemaMigration({
   });
 
   const migrationId = crypto.randomUUID();
-  if (!databaseName) {
-    throw new Error('Database name is required for migration');
-  }
-
   persistMigrationToMemory(migrationId, {
     migrationSql,
     databaseName,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -612,9 +612,6 @@ async function handleGetConnectionString({
     });
 
     if (!roleName) {
-      if (!databaseName) {
-        throw new Error('Database name is required');
-      }
       const { data } = await neonClient.getProjectBranchDatabase(
         projectId,
         branchId,
@@ -623,9 +620,6 @@ async function handleGetConnectionString({
       roleName = data.database.owner_name;
     }
   } else if (!roleName) {
-    if (!databaseName) {
-      throw new Error('Database name is required');
-    }
     const { data } = await neonClient.getProjectBranchDatabase(
       projectId,
       branchId,
@@ -686,10 +680,6 @@ async function handleSchemaMigration({
   });
 
   const migrationId = crypto.randomUUID();
-  if (!databaseName) {
-    throw new Error('Database name is required for migration');
-  }
-
   persistMigrationToMemory(migrationId, {
     migrationSql,
     databaseName,

--- a/src/toolsSchema.ts
+++ b/src/toolsSchema.ts
@@ -4,6 +4,8 @@ import { NEON_DEFAULT_DATABASE_NAME } from './constants.js';
 
 type ZodObjectParams<T> = z.ZodObject<{ [key in keyof T]: z.ZodType<T[key]> }>;
 
+const DATABASE_NAME_DESCRIPTION = `The name of the database. If not provided, the default ${NEON_DEFAULT_DATABASE_NAME} or first available database is used.`;
+
 export const nodeVersionInputSchema = z.object({});
 
 export const listProjectsInputSchema = z.object({
@@ -45,50 +47,54 @@ export const describeProjectInputSchema = z.object({
 
 export const runSqlInputSchema = z.object({
   sql: z.string().describe('The SQL query to execute'),
-  databaseName: z
-    .string()
-    .describe('The name of the database to execute the query against'),
   projectId: z
     .string()
     .describe('The ID of the project to execute the query against'),
   branchId: z
     .string()
     .optional()
-    .describe('An optional ID of the branch to execute the query against'),
+    .describe(
+      'An optional ID of the branch to execute the query against. If not provided the default branch is used.',
+    ),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });
 
 export const runSqlTransactionInputSchema = z.object({
   sqlStatements: z.array(z.string()).describe('The SQL statements to execute'),
-  databaseName: z
-    .string()
-    .describe('The name of the database to execute the query against'),
   projectId: z
     .string()
     .describe('The ID of the project to execute the query against'),
   branchId: z
     .string()
     .optional()
-    .describe('An optional ID of the branch to execute the query against'),
+    .describe(
+      'An optional ID of the branch to execute the query against. If not provided the default branch is used.',
+    ),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });
-
 export const describeTableSchemaInputSchema = z.object({
   tableName: z.string().describe('The name of the table'),
-  databaseName: z
-    .string()
-    .describe('The name of the database to get the table schema from'),
   projectId: z
     .string()
     .describe('The ID of the project to execute the query against'),
   branchId: z
     .string()
     .optional()
-    .describe('An optional ID of the branch to execute the query against'),
+    .describe(
+      'An optional ID of the branch to execute the query against. If not provided the default branch is used.',
+    ),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });
 
 export const getDatabaseTablesInputSchema = z.object({
   projectId: z.string().describe('The ID of the project'),
-  branchId: z.string().optional().describe('An optional ID of the branch'),
-  databaseName: z.string().describe('The name of the database'),
+  branchId: z
+    .string()
+    .optional()
+    .describe(
+      'An optional ID of the branch. If not provided the default branch is used.',
+    ),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });
 
 export const createBranchInputSchema = z.object({
@@ -102,12 +108,10 @@ export const prepareDatabaseMigrationInputSchema = z.object({
   migrationSql: z
     .string()
     .describe('The SQL to execute to create the migration'),
-  databaseName: z
-    .string()
-    .describe('The name of the database to execute the query against'),
   projectId: z
     .string()
     .describe('The ID of the project to execute the query against'),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });
 
 export const completeDatabaseMigrationInputSchema = z.object({
@@ -117,7 +121,7 @@ export const completeDatabaseMigrationInputSchema = z.object({
 export const describeBranchInputSchema = z.object({
   projectId: z.string().describe('The ID of the project'),
   branchId: z.string().describe('An ID of the branch to describe'),
-  databaseName: z.string().describe('The name of the database'),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });
 
 export const deleteBranchInputSchema = z.object({
@@ -143,17 +147,12 @@ export const getConnectionStringInputSchema = z.object({
     .describe(
       'The ID of the compute/endpoint. If not provided, the only available compute will be used.',
     ),
-  databaseName: z
-    .string()
-    .optional()
-    .describe(
-      'The name of the database. If not provided, the default database (usually "neondb") will be used.',
-    ),
+  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
   roleName: z
     .string()
     .optional()
     .describe(
-      'The name of the role to connect with. If not provided, the default role (usually "neondb_owner") will be used.',
+      'The name of the role to connect with. If not provided, the database owner name will be used.',
     ),
 });
 
@@ -161,11 +160,5 @@ export const provisionNeonAuthInputSchema = z.object({
   projectId: z
     .string()
     .describe('The ID of the project to provision Neon Auth for'),
-  database: z
-    .string()
-    .optional()
-    .describe(
-      `The database name to setup Neon Auth for. Defaults to '${NEON_DEFAULT_DATABASE_NAME}'`,
-    )
-    .default(NEON_DEFAULT_DATABASE_NAME),
+  database: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -94,3 +94,39 @@ $$ LANGUAGE plpgsql;
 SELECT * FROM show_db_tree();
 `,
 ];
+
+import { neonClient } from './index.js';
+import { NEON_DEFAULT_DATABASE_NAME } from './constants.js';
+
+/**
+ * Returns the default database for a project branch
+ * If a database name is provided, it returns that name
+ * Otherwise, it looks for a database named 'neondb' and returns that
+ * If 'neondb' doesn't exist, it returns the first available database
+ * Throws an error if no databases are found
+ */
+export async function getDefaultDatabase({
+  projectId,
+  branchId,
+  databaseName,
+}: {
+  projectId: string;
+  branchId: string;
+  databaseName?: string;
+}): Promise<string> {
+  if (databaseName) return databaseName;
+
+  const { data } = await neonClient.listProjectBranchDatabases(
+    projectId,
+    branchId,
+  );
+  const databases = data.databases;
+  if (databases.length === 0) {
+    throw new Error('No databases found in your project branch');
+  }
+
+  const defaultDatabase = databases.find(
+    (db) => db.name === NEON_DEFAULT_DATABASE_NAME,
+  );
+  return defaultDatabase ? defaultDatabase.name : databases[0].name;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ import { NEON_DEFAULT_DATABASE_NAME } from './constants.js';
 
 /**
  * Returns the default database for a project branch
- * If a database name is provided, it returns that name
+ * If a database name is provided, it fetches and returns that database
  * Otherwise, it looks for a database named 'neondb' and returns that
  * If 'neondb' doesn't exist, it returns the first available database
  * Throws an error if no databases are found
@@ -113,9 +113,7 @@ export async function getDefaultDatabase({
   projectId: string;
   branchId: string;
   databaseName?: string;
-}): Promise<string> {
-  if (databaseName) return databaseName;
-
+}) {
   const { data } = await neonClient.listProjectBranchDatabases(
     projectId,
     branchId,
@@ -125,8 +123,15 @@ export async function getDefaultDatabase({
     throw new Error('No databases found in your project branch');
   }
 
+  if (databaseName) {
+    const requestedDatabase = databases.find((db) => db.name === databaseName);
+    if (requestedDatabase) {
+      return requestedDatabase;
+    }
+  }
+
   const defaultDatabase = databases.find(
     (db) => db.name === NEON_DEFAULT_DATABASE_NAME,
   );
-  return defaultDatabase ? defaultDatabase.name : databases[0].name;
+  return defaultDatabase || databases[0];
 }


### PR DESCRIPTION

The MCP Server falls back to default values `neondb` and `neondb_owner` when no database and role_name is provided from LLM while invoking the tool. The Server blindly assumes that the database with the name `neondb` and role with the name `neondb_owner` exists in the project. 

This PR does two things

- Completely removes the default `neondb_owner`, and always use `database.owner_name` when no explicit role name is provided. If LLM provides a non-existing role, the tool will fail as expected
- If no database is provided, the server now looks for a database named `neondb` and uses that. If it does not exist, it uses the first available database. 

cc: @davidgomes 