### PR TITLE
feat: support basic auth method. optional pkce

### DIFF
--- a/src/oauth/utils.ts
+++ b/src/oauth/utils.ts
@@ -81,6 +81,20 @@ export const extractBearerToken = (authorizationHeader: string): string => {
   return authorizationHeader.replace(/^Bearer\s+/i, '');
 };
 
+export const extractClientCredentials = (request: Request) => {
+  const authorization = request.headers.authorization;
+  if (authorization?.startsWith('Basic ')) {
+    const credentials = atob(authorization.replace(/^Basic\s+/i, ''));
+    const [clientId, clientSecret] = credentials.split(':');
+    return { clientId, clientSecret };
+  }
+
+  return {
+    clientId: request.body.client_id,
+    clientSecret: request.body.client_secret,
+  };
+};
+
 export const toSeconds = (ms: number): number => {
   return Math.floor(ms / 1000);
 };


### PR DESCRIPTION

- [x] Add support for `client_secret_basic` auth method, supports client credentials in `Authorization` header during token exchange flow
- [x] Skip client_secret verification for public clients 
- [x] Make PKCE challenge optional, and instead add `redirect_uri` verification for token exchange

cc: @andrelandgraf  @pffigueiredo 