### PR TITLE
feat: return organization details with list and create project

### DIFF
--- a/src/toolsSchema.ts
+++ b/src/toolsSchema.ts
@@ -33,6 +33,10 @@ export const createProjectInputSchema = z.object({
     .string()
     .optional()
     .describe('An optional name of the project to create.'),
+  org_id: z
+    .string()
+    .optional()
+    .describe('Create project in a specific organization.'),
 });
 
 export const deleteProjectInputSchema = z.object({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { NEON_DEFAULT_DATABASE_NAME } from './constants.js';
-import { Api } from '@neondatabase/api-client';
+import { Api, Organization } from '@neondatabase/api-client';
 
 export const splitSqlStatements = (sql: string) => {
   return sql.split(';').filter(Boolean);
@@ -137,4 +137,51 @@ export async function getDefaultDatabase(
     (db) => db.name === NEON_DEFAULT_DATABASE_NAME,
   );
   return defaultDatabase || databases[0];
+}
+
+/**
+ * Resolves the organization ID for API calls that require org_id parameter.
+ *
+ * For new users (those without billing_account), this function fetches user's organizations and auto-selects only organization managed by console. If there are multiple organizations managed by console, it throws an error asking user to specify org_id.
+ *
+ * For existing users (with billing_account), returns undefined to use default behavior.
+ *
+ * @param params - The parameters object that may contain org_id
+ * @param neonClient - The Neon API client
+ * @returns The organization to use, or undefined for default behavior
+ */
+export async function getOrgIdForNewUsers(
+  params: { org_id?: string },
+  neonClient: Api<unknown>,
+): Promise<Organization | undefined> {
+  if (params.org_id) {
+    const { data } = await neonClient.getOrganization(params.org_id);
+    return data;
+  }
+
+  const { data: user } = await neonClient.getCurrentUserInfo();
+  if (user.billing_account) {
+    return undefined;
+  }
+
+  const { data: response } = await neonClient.getCurrentUserOrganizations();
+  const organizations = response.organizations || [];
+  const consoleOrganizations = organizations.filter(
+    (org) => org.managed_by === 'console',
+  );
+
+  if (consoleOrganizations.length === 0) {
+    throw new Error('No organizations found for this user');
+  }
+
+  if (consoleOrganizations.length === 1) {
+    return consoleOrganizations[0];
+  } else {
+    const orgList = consoleOrganizations
+      .map((org) => `- ${org.name} (ID: ${org.id})`)
+      .join('\n');
+    throw new Error(
+      `Multiple organizations found. Please specify the org_id parameter with one of the following organization IDs:\n${orgList}`,
+    );
+  }
 }


### PR DESCRIPTION


For a free organization feature, new projects should be created in the default organization and not under a personal account.  This PR adds additional logic to resolve the user's organization for `list_projects` and `create_project` tools


Resolution: 

1. Fetch user details and verify if the project can be created under a personal/individual account. If yes, proceed with the tool execution
2.  If not, the user should have a free organization. Fetch and filter organizations managed by `console`
3. If the filter  results in only one organization, execute the tool under this organization scope
4. If the filter returns multiple orgs, throw error requesting user/agent for an `org_id`


cc: @pffigueiredo @davidgomes 