### PR TITLE
fix: mark params as required argument in tool arguments

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -43,10 +43,7 @@ export const createMcpServer = (context: ServerContext) => {
     server.tool(
       tool.name,
       tool.description,
-      // In case of no input parameters, the tool is invoked with an empty`{}`
-      // however zod expects `{params: {}}`
-      // To workaround this, we use `optional()`
-      { params: tool.inputSchema.optional() },
+      { params: tool.inputSchema },
       async (args, extra) => {
         return await startNewTrace(async () => {
           return await startSpan(
@@ -71,7 +68,6 @@ export const createMcpServer = (context: ServerContext) => {
                 account: context.account,
               };
               try {
-                // @ts-expect-error: Ignore zod optional
                 return await toolHandler(args, neonClient, extraArgs);
               } catch (error) {
                 logger.error('Tool call error:', {


### PR DESCRIPTION
The tool argument `params` was marked as optional, hence some of the MCP clients where sending empty arguments `{}` causing `undefined` error when server tries to read `params.org_id` 

Mostly happened with Vercel MCP and for some users on Claude Desktop[tele](url)