### PR TITLE
chore: allow manual triggers. update preview trigger

### DIFF
--- a/.github/workflows/koyeb-preview.yml
+++ b/.github/workflows/koyeb-preview.yml
@@ -1,9 +1,9 @@
 name: Build and deploy backend to preview
 
 on:
-  push:
-    branches:
-      - 'koyeb-preview'
+  workflow_dispatch:
+  pull_request:
+    types: [labeled]
 
 jobs:
   deploy:
@@ -11,6 +11,7 @@ jobs:
       group: '${{ github.ref_name }}'
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/koyeb-preview.yml
+++ b/.github/workflows/koyeb-preview.yml
@@ -3,7 +3,7 @@ name: Build and deploy backend to preview
 on:
   workflow_dispatch:
   pull_request:
-    types: [labeled]
+    types: [synchronize, labeled]
 
 jobs:
   deploy:

--- a/.github/workflows/koyeb-preview.yml
+++ b/.github/workflows/koyeb-preview.yml
@@ -21,7 +21,7 @@ jobs:
           api_token: '${{ secrets.KOYEB_PREVIEW_TOKEN }}'
       - name: Build and deploy to Koyeb preview
         run: |
-          koyeb deploy . platform-${{ github.ref_name }}/main \
+          koyeb deploy . platform-koyeb-preview/main \
             --instance-type nano \
             --region was \
             --archive-builder docker \

--- a/.github/workflows/koyeb-prod.yml
+++ b/.github/workflows/koyeb-prod.yml
@@ -1,6 +1,7 @@
 name: Build and deploy backend to production
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'main'
@@ -11,6 +12,8 @@ jobs:
       group: '${{ github.ref_name }}'
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    # Only main branch is allowed to deploy to production
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION

- [x] Allow manual trigger for production deployment from Github Actions (`workflow_dispatch`) 
- [x] Only `main` branch should be allowed to deployed to production
- [x]  Change preview deployment trigger based on PR label - `deploy-preview` 