### PR TITLE
feat: a tool to list current user's organizations

### DIFF
--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -20,6 +20,7 @@ import {
   runSqlInputSchema,
   runSqlTransactionInputSchema,
   listSlowQueriesInputSchema,
+  listOrganizationsInputSchema,
 } from './toolsSchema.js';
 
 export const NEON_TOOLS = [
@@ -589,5 +590,11 @@ export const NEON_TOOLS = [
     name: 'list_branch_computes' as const,
     description: 'Lists compute endpoints for a project or specific branch',
     inputSchema: listBranchComputesInputSchema,
+  },
+  {
+    name: 'list_organizations' as const,
+    description:
+      'Lists all organizations that the current user has access to. Optionally filter by organization name or ID using the search parameter.',
+    inputSchema: listOrganizationsInputSchema,
   },
 ];

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -37,7 +37,41 @@ async function handleListProjects(
   if (response.status !== 200) {
     throw new Error(`Failed to list projects: ${response.statusText}`);
   }
-  return response.data.projects;
+
+  let projects = response.data.projects;
+
+  // If search is provided and no org_id specified, and no projects found in personal account,
+  // search across all user organizations
+  if (params.search && !params.org_id && projects.length === 0) {
+    const organizations = await handleListOrganizations(
+      neonClient,
+      extra.account,
+    );
+
+    // Search projects across all organizations
+    const allProjects = [];
+    for (const org of organizations) {
+      // Skip the default organization
+      if (organization?.id === org.id) {
+        continue;
+      }
+
+      const orgResponse = await neonClient.listProjects({
+        ...params,
+        org_id: org.id,
+      });
+      if (orgResponse.status === 200) {
+        allProjects.push(...orgResponse.data.projects);
+      }
+    }
+
+    // If we found projects in other organizations, return them
+    if (allProjects.length > 0) {
+      projects = allProjects;
+    }
+  }
+
+  return projects;
 }
 
 async function handleCreateProject(

--- a/src/tools/toolsSchema.ts
+++ b/src/tools/toolsSchema.ts
@@ -288,3 +288,12 @@ export const listBranchComputesInputSchema = z.object({
       'The ID of the branch. If provided, endpoints for this specific branch will be listed.',
     ),
 });
+
+export const listOrganizationsInputSchema = z.object({
+  search: z
+    .string()
+    .optional()
+    .describe(
+      'Search organizations by name or ID. You can specify partial name or ID values to filter results.',
+    ),
+});

--- a/src/tools/utils.ts
+++ b/src/tools/utils.ts
@@ -190,3 +190,18 @@ export async function getOrgByOrgIdOrDefault(
     );
   }
 }
+
+export function filterOrganizations(
+  organizations: Organization[],
+  search?: string,
+) {
+  if (!search) {
+    return organizations;
+  }
+  const searchLower = search.toLowerCase();
+  return organizations.filter(
+    (org) =>
+      org.name.toLowerCase().includes(searchLower) ||
+      org.id.toLowerCase().includes(searchLower),
+  );
+}


### PR DESCRIPTION
closes #90 

- When `list_project` with `search` query returns no result from personal account, extend the search to user's all organization
- If the tool was called with `org_id`, no need to look for project in other organizations
