### PR TITLE
fix: replace fetch error with no API KEY error message

### DIFF
--- a/src/initConfig.ts
+++ b/src/initConfig.ts
@@ -90,7 +90,7 @@ export const parseArgs = (): Args => {
     };
   }
 
-  if (args.length < 3) {
+  if (args.length < 4) {
     logger.error(
       'Please provide a NEON_API_KEY as a command-line argument - you can get one through the Neon console: https://neon.tech/docs/manage/api-keys',
     );


### PR DESCRIPTION
Running `npx @neondatabase/mcp-server-neon start` without `NEON_API_KEY` as the fourth argument currently throws a fetch error (unauthorized) due to the API key being `undefined`. This PR replaces the fetch error with the appropriate error message by fixing an if condition in the `parseArgs function.

## Before

<img width="795" height="581" alt="Screenshot 2025-08-01 at 11 10 27 PM" src="https://github.com/user-attachments/assets/bd938abe-8aa4-4cad-b4ad-a0df71f7d1e9" />

## After

<img width="962" height="103" alt="Screenshot 2025-08-01 at 11 11 06 PM" src="https://github.com/user-attachments/assets/7f2c2422-05ff-4c5b-bec4-ffe2d55cee3a" />
